### PR TITLE
fix: use a platform-specific path segment separator instead of a hardcoded one;

### DIFF
--- a/src/core/build/user-utils/optimize.ts
+++ b/src/core/build/user-utils/optimize.ts
@@ -3,7 +3,7 @@ import { InertConfig, InertFile } from "../types";
 import imageSize from "image-size";
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import sharp from "sharp";
-import { resolve, join, dirname } from "path";
+import { resolve, join, dirname, sep} from "path";
 import { resolveOutDir } from "../utils/dirs";
 import { cyan } from "chalk";
 import { asyncChecksum } from "../utils/checksum";
@@ -90,7 +90,7 @@ export default function optimize(outFolder: string, options: OptimizeOptions) {
       resolve(
         process.cwd(),
         resolveOutDir(config, config.build.outDirs[outFolder]),
-        `webp/${path_extless.includes("/") ? dirname(path_extless) : ""}`
+        `webp/${path_extless.includes(sep) ? dirname(path_extless) : ""}`
       ),
       {
         recursive: true,


### PR DESCRIPTION
The building process fails on Windows due to the detection attempt of a hardcoded path separator, so it's not possible to build `axios-docs` locally if we have images inside subpaths.